### PR TITLE
Handle users who block the bot by automatically pausing their notifications

### DIFF
--- a/src/main/java/com/github/novskey/novabot/notifier/PokeNotificationSender.java
+++ b/src/main/java/com/github/novskey/novabot/notifier/PokeNotificationSender.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.function.Consumer;
 
 
 public class PokeNotificationSender extends NotificationSender implements Runnable {
@@ -111,11 +112,17 @@ public class PokeNotificationSender extends NotificationSender implements Runnab
             localLog.info(String.format("Checking supporter status of %s", user.getName()));
             novaBot.lastUserRoleChecks.put(userID, currentTime);
             if (checkSupporterStatus(user)) {
-                user.openPrivateChannel().queue(channel -> channel.sendMessage(message).queue());
+                user.openPrivateChannel().queue(channel -> channel.sendMessage(message).queue(), logPMBlocked(user));
             }
         } else {
             user.openPrivateChannel().queue(channel -> channel.sendMessage(message).queue());
         }
+    }
+
+    private Consumer<Throwable> logPMBlocked(User user) {
+        localLog.info(user.getName() + " has messages blocked. Please inform them to pause notifications instead of blocking. Pausing user automatically.");
+        novaBot.dataManager.pauseUser(user.getId());
+        return null;
     }
 
     private void sendChannelAlert(Message message, String channelId) {


### PR DESCRIPTION
## Problem
`user.openPrivateChannel().queue(channel -> channel.sendMessage(message).queue());`
JDA `.queue()` will throw an exception when a user blocks the bot. These exceptions are logged into the error log file. I don't know why a user would block the bot...that's what the `!pause` command is for. Nevertheless, we need to properly handle this as it will use up a tremendous amount of disk space at scale.

## Solution
The ideal situation would be if the async `.queue()` would allow some type of try/catch exception handling, but that's difficult to do without breaking concurrency in async threads. Luckily, JDA's `.queue()` method has a constructor with two arguments. The first argument being a consumer on success (which is already uses to log a message to the logfile). The second argument is a consumer on failure, which will catch any exceptions that the notification thread runs into.

Using this constructor, it's an easy addition to neatly log the incident with a method that returns a Consumer<Throwable> object, which will be null. This method simply logs the incident using the user's name so as to easily identify them by reading the logs. Also, it makes sense to automatically pause their alerts because if we don't, this PR is semi-worthless.
```
    private Consumer<Throwable> logPMBlocked(User user) {
        localLog.info(user.getName() + " has messages blocked. Please inform them to pause notifications instead of blocking. Pausing user automatically.");
        novaBot.dataManager.pauseUser(user.getId());
        return null;
    }
```