### PR TITLE
added encounter id for Hydro

### DIFF
--- a/src/main/java/com/github/novskey/novabot/data/ScanDBManager.java
+++ b/src/main/java/com/github/novskey/novabot/data/ScanDBManager.java
@@ -435,7 +435,8 @@ public class ScanDBManager  {
                       "       form," +
                       "       cp," +
                       "       level, " +
-                      "       weather_boosted_condition " +
+                      "       weather_boosted_condition, " +
+                      "       encounter_id " +
                       "FROM sightings " +
                       "WHERE updated >= " +
                             (scannerDb.getProtocol().equals("mysql")
@@ -683,7 +684,8 @@ public class ScanDBManager  {
                         cp = (Integer) rs.getObject(12);
                         Integer level = (Integer) rs.getObject(13);
                         weather = rs.getInt(14);
-                        pokeSpawn = new PokeSpawn(id, lat, lon, disappearTime, attack, defense, stamina, move1, move2, 0, 0, gender, form, cp, level, weather);
+                        String encounter_id = rs.getString(15);
+                        pokeSpawn = new PokeSpawn(id, lat, lon, disappearTime, attack, defense, stamina, move1, move2, 0, 0, gender, form, cp, level, weather, encounter_id);
 
                         break;
                 }

--- a/src/main/java/com/github/novskey/novabot/pokemon/PokeSpawn.java
+++ b/src/main/java/com/github/novskey/novabot/pokemon/PokeSpawn.java
@@ -142,6 +142,7 @@ public class PokeSpawn extends Spawn
 
         getProperties().put("weather","unkn");
         getProperties().put("weather_icon","");
+        getProperties().put("encounter_id","");
     }
 
     public PokeSpawn(final int id, final double lat, final double lon, final ZonedDateTime disappearTime, final Integer attack, final Integer defense, final Integer stamina, final Integer move1, final Integer move2, final float weight, final float height, final Integer gender, final Integer form, Integer cp, double cpModifier) {
@@ -156,13 +157,14 @@ public class PokeSpawn extends Spawn
         getProperties().put("level", String.valueOf(level));
     }
 
-    public PokeSpawn(int id, double lat, double lon, ZonedDateTime disappearTime, Integer attack, Integer defense, Integer stamina, Integer move1, Integer move2, int weight, int height, Integer gender, Integer form, Integer cp, Integer level, int weather) {
+    public PokeSpawn(int id, double lat, double lon, ZonedDateTime disappearTime, Integer attack, Integer defense, Integer stamina, Integer move1, Integer move2, int weight, int height, Integer gender, Integer form, Integer cp, Integer level, int weather, String encounter_id) {
         this(id,lat,lon,disappearTime,attack,defense,stamina,move1,move2,weight,height,gender,form,cp,level);
         Weather w = Weather.fromId(weather);
         if (w != null) {
             getProperties().replace("weather", w.toString());
             getProperties().replace("weather_icon", w.getEmote());
         }
+        getProperties().replace("encounter_id",encounter_id);
     }
 
     public PokeSpawn(int id, double lat, double lon, ZonedDateTime disappearTime, Integer attack, Integer defense, Integer stamina, Integer move1, Integer move2, float weight, float height, Integer gender, Integer form, Integer cp, double cpMod, int weather) {


### PR DESCRIPTION
encounter id for Hydro74000 forks added. Only tested on Postgresql. Text substitution is `<encounter_id>`. jar file attached for tester. Remove `.zip` from the attached file to run.
[novabot-1.2-jar-with-dependencies-enc-id-hydro.jar.zip](https://github.com/novskey/novabot/files/1732754/novabot-1.2-jar-with-dependencies-enc-id-hydro.jar.zip)


