### PR TITLE
Allow usage of pokemon id instead of name

### DIFF
--- a/src/main/java/com/github/novskey/novabot/parser/Parser.java
+++ b/src/main/java/com/github/novskey/novabot/parser/Parser.java
@@ -232,7 +232,13 @@ public class Parser {
                         }
                         break;
                     case Pokemon:
-                        final Pokemon pokemon = new Pokemon(trimmed);
+                        final Pokemon pokemon;
+                        if (getInt(trimmed) != null) {
+                            pokemon = new Pokemon(Pokemon.idToName(getInt(trimmed)));
+                        }
+                        else {
+                            pokemon = new Pokemon(trimmed);
+                        }
                         if (pokemon.name == null) {
                             malformed.add(string);
                         }

--- a/src/main/java/com/github/novskey/novabot/parser/Parser.java
+++ b/src/main/java/com/github/novskey/novabot/parser/Parser.java
@@ -87,6 +87,9 @@ public class Parser {
         } else if (valid.contains(ArgType.Pokemon) && Pokemon.nameToID(trimmed) != 0) {
             argument.setType(ArgType.Pokemon);
             argument.setParams(new Object[]{trimmed});
+        } else if (valid.contains(ArgType.Pokemon) && getInt(trimmed) != null && Pokemon.idToName(getInt(trimmed)) != "") {
+            argument.setType(ArgType.Pokemon);
+            argument.setParams(new Object[]{Pokemon.idToName(getInt(trimmed))});
         } else if (valid.contains(ArgType.Egg) && EGG_PATTERN.matcher(trimmed).matches()) {
             argument.setType(ArgType.Egg);
             Matcher matcher = ONLY_NUMBERS.matcher(trimmed);

--- a/src/main/java/com/github/novskey/novabot/parser/Parser.java
+++ b/src/main/java/com/github/novskey/novabot/parser/Parser.java
@@ -24,7 +24,7 @@ public class Parser {
     private static final Pattern CP_PATTERN = Pattern.compile("(cp[0-9]+)|([0-9]+cp)");
     private static final Pattern IV_PATTERN = Pattern.compile("iv[0-9]+|([0-9]+iv)|[0-9]+");
     private static final Pattern EGG_PATTERN = Pattern.compile("egg[1-5]");
-
+	private static final Pattern POKE_PATTERN = Pattern.compile("p[0-9]+|pid[0-9]+|poke[0-9]+|pokemon[0-9]+");
 
     private final NovaBot novaBot;
 
@@ -87,9 +87,9 @@ public class Parser {
         } else if (valid.contains(ArgType.Pokemon) && Pokemon.nameToID(trimmed) != 0) {
             argument.setType(ArgType.Pokemon);
             argument.setParams(new Object[]{trimmed});
-        } else if (valid.contains(ArgType.Pokemon) && getInt(trimmed) != null && Pokemon.idToName(getInt(trimmed)) != "") {
+        } else if (valid.contains(ArgType.Pokemon) && POKE_PATTERN.matcher(trimmed).matches()) {
             argument.setType(ArgType.Pokemon);
-            argument.setParams(new Object[]{Pokemon.idToName(getInt(trimmed))});
+            argument.setParams(new Object[]{Pokemon.idToName(getInt(trimmed.replaceAll("[^\\d.]", "")))});
         } else if (valid.contains(ArgType.Egg) && EGG_PATTERN.matcher(trimmed).matches()) {
             argument.setType(ArgType.Egg);
             Matcher matcher = ONLY_NUMBERS.matcher(trimmed);
@@ -233,8 +233,8 @@ public class Parser {
                         break;
                     case Pokemon:
                         final Pokemon pokemon;
-                        if (getInt(trimmed) != null) {
-                            pokemon = new Pokemon(Pokemon.idToName(getInt(trimmed)));
+                        if (POKE_PATTERN.matcher(trimmed).matches()) {
+                            pokemon = new Pokemon(getInt(trimmed.replaceAll("[^\\d.]", "")));
                         }
                         else {
                             pokemon = new Pokemon(trimmed);

--- a/src/main/java/com/github/novskey/novabot/pokemon/Pokemon.java
+++ b/src/main/java/com/github/novskey/novabot/pokemon/Pokemon.java
@@ -448,7 +448,12 @@ public class Pokemon {
                 return 2036;
             }
             default: {
-                return Pokemon.VALID_NAMES.indexOf(pokeName) + 1;
+				if (id - 1 < 0 || id - 1 >= Pokemon.VALID_NAMES.size()) {
+					return "";
+				}
+				else {
+					return Pokemon.VALID_NAMES.get(id - 1);
+				}
             }
         }
     }

--- a/src/main/java/com/github/novskey/novabot/pokemon/Pokemon.java
+++ b/src/main/java/com/github/novskey/novabot/pokemon/Pokemon.java
@@ -111,7 +111,7 @@ public class Pokemon {
     }
 
     public Pokemon(final int id, final float min_iv, final float max_iv) {
-        this(idToName(id));
+		this(idToName(id));
         this.miniv = min_iv;
         this.maxiv = max_iv;
     }
@@ -127,14 +127,14 @@ public class Pokemon {
         this.maxcp = maxcp;
     }
 
-    private Pokemon(final int id) {
+    public Pokemon(final int id) {
+		this(idToName(id));
         this.miniv = 0.0f;
         this.maxiv = 100.0f;
-        this.name = idToName(id);
     }
 
     public Pokemon(final int id, final Location location, final float miniv, final float maxiv) {
-        this(id);
+		this(idToName(id));
         this.location = location;
         this.miniv = miniv;
         this.maxiv = maxiv;
@@ -318,8 +318,13 @@ public class Pokemon {
             case 2036: {
                 return "unownz";
             }
-            default: {
-                return Pokemon.VALID_NAMES.get(id - 1);
+			default: {
+				if (id - 1 < 0 || id - 1 >= Pokemon.VALID_NAMES.size()) {
+					return null;
+				}
+				else {
+					return Pokemon.VALID_NAMES.get(id - 1);
+				}
             }
         }
     }
@@ -447,13 +452,8 @@ public class Pokemon {
             case "unownz": {
                 return 2036;
             }
-            default: {
-				if (id - 1 < 0 || id - 1 >= Pokemon.VALID_NAMES.size()) {
-					return "";
-				}
-				else {
-					return Pokemon.VALID_NAMES.get(id - 1);
-				}
+			default: {
+                return Pokemon.VALID_NAMES.indexOf(pokeName) + 1;
             }
         }
     }


### PR DESCRIPTION
This PR allows users to use the pokemons id inside commands.
e.g. `!addpokemon 201`

<img width="452" alt="ohne titel 999" src="https://user-images.githubusercontent.com/1949038/36936136-4e7ac1f2-1f01-11e8-8bd7-cbdf9a79ca10.png">
